### PR TITLE
Changes to how init works

### DIFF
--- a/game/__Renpy__/__Objects__.rpy
+++ b/game/__Renpy__/__Objects__.rpy
@@ -20,6 +20,27 @@ init python:
         renpy.pause(speed)
         renpy.hide_screen("universal_walk")
     
+    class silver_init_object(object):
+        def __init__(self, **kwargs):
+            self.__dict__.update(**kwargs)
+
+        # inits object params as new global vars if they dont already exist 
+        def init(self, force=False):
+            dic = {}
+            if force:
+                variables_to_set = self.__dict__.keys()
+            else:
+                variables_to_set = [ att for att in self.__dict__.keys() if att not in globals() ]
+
+            for var_name in variables_to_set:
+                var_value = self.__dict__[var_name]
+                if isinstance(var_value, unicode):
+                    dic[var_name] = str(var_value)
+                else:
+                    dic[var_name] = var_value
+            globals().update(dic)
+            return dic
+    
     class silver_scroll(object):
         id = 0
         name = ""

--- a/game/__Renpy__/_astoria_/__astoria_init__.rpy
+++ b/game/__Renpy__/_astoria_/__astoria_init__.rpy
@@ -163,57 +163,59 @@ label astoria_init:
 
 
 label astoria_progress_init:
+    
+    python:
+        # New init format that allows for dynamic addition of new vars
+        silver_init_object(
+            astoria_spells = [0,0,0,0,0,0],
+            astoria_spell_progress = 0,
+            astoria_affection = 0,
+            astoria_points = 0,
 
-    if not hasattr(renpy.store,'astoria_name') or reset_persistants:
+            ##Flags
+            astoria_busy = False,
+            astoria_unlocked = False,
+            astoria_wardrobe_unlocked = False,
+            chitchated_with_astoria = False,
+            
+            days_since_astoria = 0,
+            astoria_arrival_day = 30,
+            astoria_arrvial_whoring = 9,
+            
+            ##Events
+            ministry_letter          = False,
+            ministry_letter_received = False,
+            hermione_on_the_lookout  = False,
+            hermione_finds_astoria   = False,
+            snape_on_the_lookout     = False,
+            tonks_intro_happened     = False,
+            spells_unlocked          = False,
+            snape_gave_spellbook     = False,
+            third_curse_got_cast     = False,
+            astoria_book_intro_happened = False,
+            astoria_intro_completed  = False,
+            
+            ##Tonks events
+            spells_locked = False,
+            astoria_tonks_event_in_progress = False,
+            astoria_tonks_1_completed = False,
+            astoria_tonks_2_completed = False,
+            astoria_tonks_3_completed = False,
+            astoria_tonks_4_completed = False,
+            astoria_tonks_5_completed = False,
+            astoria_tonks_6_completed = False,
 
-        ##Favour stuff
+            ##Names
+            astoria_name = "Miss Greengrass",
+            ast_genie_name = "Dumby",
+            ast_susan_name = "Cow",
+            ast_tonks_name = "Old Hag",
 
-        ##Stats
-        $ astoria_spells = [0,0,0,0,0,0]
-        $ astoria_spell_progress = 0
-        $ astoria_affection = 0
-        $ astoria_points = 0
+            # Example Variable
+            ast_new_var = "new_string"
+        ).init(reset_persistants)
 
-        ##Flags
-        $ astoria_busy = False
-        $ astoria_unlocked = False
-        $ astoria_wardrobe_unlocked = False
-        $ chitchated_with_astoria = False
-        
-        $ days_since_astoria = 0
-        $ astoria_arrival_day = 30
-        $ astoria_arrvial_whoring = 9
-        
-        ##Events
-        $ ministry_letter          = False
-        $ ministry_letter_received = False
-        $ hermione_on_the_lookout  = False
-        $ hermione_finds_astoria   = False
-        $ snape_on_the_lookout     = False
-        $ tonks_intro_happened     = False
-        $ spells_unlocked          = False
-        $ snape_gave_spellbook     = False
-        $ third_curse_got_cast     = False
-        $ astoria_book_intro_happened = False
-        $ astoria_intro_completed  = False
-        
-        ##Tonks events
-        $ spells_locked = False
-        $ astoria_tonks_event_in_progress = False
-        $ astoria_tonks_1_completed = False
-        $ astoria_tonks_2_completed = False
-        $ astoria_tonks_3_completed = False
-        $ astoria_tonks_4_completed = False
-        $ astoria_tonks_5_completed = False
-        $ astoria_tonks_6_completed = False
-
-        ##Names
-        $ astoria_name = "Miss Greengrass"
-        $ ast_genie_name = "Dumby"
-        $ ast_susan_name = "Cow"
-        $ ast_tonks_name = "Old Hag"
-        
-
-    #if not hasattr(renpy.store,'ADD') or reset_persistants:
+        # deletes the unneeded example variable that was initialized
+        del ast_new_var
     
     return


### PR DESCRIPTION
This is an example of what I plan on implementing to replace the current way we init vars similar to the ones in the example it replaces the `hasattr(renpy.store` that needs to be in front of every variable we want to make sure is loaded as well as allows for dynamic addition to any of the lists without needing to worry about crushing the stored values of other variables.